### PR TITLE
Fixed PATH export

### DIFF
--- a/src/utils/get-hook-script.js
+++ b/src/utils/get-hook-script.js
@@ -38,7 +38,7 @@ function platformSpecific() {
         # Add common path where Node can be found
         # Brew standard installation path /usr/local/bin
         # Node standard installation path /usr/local
-        export PATH=$PATH:/usr/local/bin:/usr/local`
+        export PATH="$PATH:/usr/local/bin:/usr/local"`
       )
     ]
 


### PR DESCRIPTION
When using Husky inside WSL, there was a problem with spaces in Windows paths (i.e. when `NVIDIA Corporation` directory is in `PATH`):
```
.git/hooks/pre-commit: 31: export: (x86)/NVIDIA: bad variable name
```

This commit fixes it by adding double quotes for `export PATH`.